### PR TITLE
refactor(functions): extend database mock types

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,8 @@
     "bad-words": "^1.5.1",
     "firebase-admin": "^4.2.1",
     "firebase-functions": "^0.5",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "typescript": "^3.6.4"
   },
   "main": "./lib/src/index.js",
   "private": true,
@@ -20,7 +21,7 @@
     "@types/chai": "^3.5.2",
     "@types/chai-as-promised": "0.0.30",
     "@types/mocha": "^2.2.41",
-    "@types/mock-require": "^1.3.3",
+    "@types/mock-require": "^2.0.0",
     "@types/nock": "^8.2.1",
     "@types/sinon": "^2.2.1",
     "chai": "^3.5.0",

--- a/functions/spec/fake-db.ts
+++ b/functions/spec/fake-db.ts
@@ -1,8 +1,12 @@
 import * as _ from 'lodash';
 import * as mock from 'mock-require';
 
-let _values;
-let pushCount;
+interface ValuesProps {
+  [key: string]: string;
+}
+
+let _values: ValuesProps;
+let pushCount: number;
 reset();
 
 export function reset() {
@@ -14,7 +18,7 @@ export function has(path: string): boolean {
   return _values.hasOwnProperty(path);
 }
 
-export function get(path: string): Promise<string> {
+export function get(path: string): Promise<string | null> {
   if (!_values.hasOwnProperty(path)) {
     return Promise.resolve(null);
   }
@@ -26,7 +30,7 @@ export function set(path: string, value: any): Promise<void> {
   return Promise.resolve();
 }
 
-export function push(path: string, value: any): Promise<any> {
+export function push(path: string, value: any): Promise<void> {
   _values[`${path}/pushprefix-${pushCount}`] = value;
   pushCount++;
   return Promise.resolve();
@@ -37,7 +41,10 @@ export function remove(path: string): Promise<void> {
   return Promise.resolve();
 }
 
-export async function transaction(path: string, callback): Promise<any> {
+export async function transaction(
+  path: string,
+  callback: (get: string | null) => Promise<void>
+): Promise<any> {
   return set(path, callback(await get(path)));
 }
 

--- a/functions/src/db.ts
+++ b/functions/src/db.ts
@@ -27,7 +27,7 @@ export function set(path: string, value: any): Promise<void> {
   return admin.database().ref(path).set(value)
 }
 
-export function push(path: string, value: any): Promise<any> {
+export function push(path: string, value: any): Promise<void> {
   return admin.database().ref(path).push(value);
 }
 


### PR DESCRIPTION
@laurenzlong thanks so much for the Firebase testing abstraction layer. 
Your database is quite helpful and I will be using it on my own project. I extended the typings for the `fake-db.ts`. This is something that I need it for my own project and thought it might be handy for yours too.

In case you are interested, please let me know if there are any changes you require from this PR.
